### PR TITLE
Use semicolon entry separator in gcc LIBRARY_PATH environment variable

### DIFF
--- a/packaging/install.bat
+++ b/packaging/install.bat
@@ -2,4 +2,4 @@ REM Adds the containing directory's "include" and "lib" subdirs to appropriate g
 
 setlocal
 setx CPLUS_INCLUDE_PATH "%~dp0include;%CPLUS_INCLUDE_PATH%"
-setx LIBRARY_PATH "%~dp0lib:%LIBRARY_PATH%"
+setx LIBRARY_PATH "%~dp0lib;%LIBRARY_PATH%"


### PR DESCRIPTION
This causes the `LIBRARY_PATH ` environment variable to be set incorrectly when appending on to an already existing `LIBRARY_PATH` variable.